### PR TITLE
Add typed event emitter to renderers

### DIFF
--- a/js/packages/web-renderer/index.ts
+++ b/js/packages/web-renderer/index.ts
@@ -9,8 +9,20 @@ import {
 import WorkletProcessor from './raw/WorkletProcessor';
 import WasmModule from './raw/elementary-wasm';
 
+type EventListener<E> = (event: E) => void
 
-export default class WebAudioRenderer extends events.EventEmitter {
+declare interface EventEmitter<Events extends ElemEvents> {
+  on<K extends keyof ElemEvents>(eventName: K, listener: EventListener<ElemEvents[K]>);
+}
+
+class EventEmitter<Events extends ElemEvents> extends events.EventEmitter {}
+
+type ElemEvents = {
+  "load": void;
+  "scope": { data: Float32Array, source: string };
+}
+
+export default class WebAudioRenderer extends EventEmitter<ElemEvents> {
   private _worklet: any;
   private _renderer: Renderer;
   private _timer: any;

--- a/js/packages/web-renderer/package-lock.json
+++ b/js/packages/web-renderer/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@elemaudio/core": {
-      "version": "2.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@elemaudio/core/-/core-2.0.0-alpha.0.tgz",
-      "integrity": "sha512-QU4fGp/cQ3mEsm+TVnGKnsZ2IIIItpITF25bM4+eUKUzVKLorwvwnOiQ2fFFPvoAbmEgphXs88KLopURfo6qzQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@elemaudio/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-3CIEnSpzFArUMXzlJWuFfapbAWUyCXU2KyYnTQVX8BBgMLYuPrQszRBJX2m325MDiseqzlGYCMJIkQXWhEkMIA==",
       "dependencies": {
         "invariant": "^2.2.4",
         "shallowequal": "^1.1.0"
@@ -569,9 +569,9 @@
   },
   "dependencies": {
     "@elemaudio/core": {
-      "version": "2.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@elemaudio/core/-/core-2.0.0-alpha.0.tgz",
-      "integrity": "sha512-QU4fGp/cQ3mEsm+TVnGKnsZ2IIIItpITF25bM4+eUKUzVKLorwvwnOiQ2fFFPvoAbmEgphXs88KLopURfo6qzQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@elemaudio/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-3CIEnSpzFArUMXzlJWuFfapbAWUyCXU2KyYnTQVX8BBgMLYuPrQszRBJX2m325MDiseqzlGYCMJIkQXWhEkMIA==",
       "requires": {
         "invariant": "^2.2.4",
         "shallowequal": "^1.1.0"


### PR DESCRIPTION
This PR implements the following features:

- [ ] Adds types to the web renderer
- [ ] Adds types to the offline renderer
- [ ] Updates event emitter to use `emittery`

Note that this PR is still a work in progress.