### PR TITLE
Include functional for win builds

### DIFF
--- a/runtime/elem/GraphNode.h
+++ b/runtime/elem/GraphNode.h
@@ -4,7 +4,7 @@
 #include "Value.h"
 
 #include <unordered_map>
-
+#include <functional>
 
 namespace elem
 {

--- a/runtime/elem/Value.h
+++ b/runtime/elem/Value.h
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <variant>
 #include <vector>
-
+#include <functional>
 
 namespace elem
 {


### PR DESCRIPTION
I was hitting some errors due to ```std::functional``` not being available on Windows. 
Specifically this setup: 

```
-- Building for: Visual Studio 17 2022
-- The C compiler identification is MSVC 19.35.3221
-- The CXX compiler identification is MSVC 19.35.32217.1
```

Seems to be able to build after the includes