### PR TITLE
Fix el.capture causing crash in offline renderer

### DIFF
--- a/runtime/elem/builtins/Capture.h
+++ b/runtime/elem/builtins/Capture.h
@@ -13,7 +13,7 @@ namespace elem
     struct CaptureNode : public GraphNode<FloatType> {
         CaptureNode(NodeId id, FloatType const sr, int const blockSize)
             : GraphNode<FloatType>::GraphNode(id, sr, blockSize),
-              ringBuffer(1, static_cast<size_t>(sr))
+              ringBuffer(1, juce::nextPowerOfTwo(static_cast<size_t>(sr)))
         {
         }
 

--- a/runtime/elem/builtins/Capture.h
+++ b/runtime/elem/builtins/Capture.h
@@ -4,6 +4,7 @@
 #include "../MultiChannelRingBuffer.h"
 
 #include "helpers/Change.h"
+#include "helpers/BitUtils.h"
 
 
 namespace elem
@@ -13,7 +14,7 @@ namespace elem
     struct CaptureNode : public GraphNode<FloatType> {
         CaptureNode(NodeId id, FloatType const sr, int const blockSize)
             : GraphNode<FloatType>::GraphNode(id, sr, blockSize),
-              ringBuffer(1, juce::nextPowerOfTwo(static_cast<size_t>(sr)))
+              ringBuffer(1, elem::bitceil(static_cast<size_t>(sr)))
         {
         }
 

--- a/runtime/elem/builtins/Delays.h
+++ b/runtime/elem/builtins/Delays.h
@@ -5,31 +5,11 @@
 
 #include "helpers/Change.h"
 #include "helpers/RefCountedPool.h"
+#include "helpers/BitUtils.h"
 
 
 namespace elem
 {
-
-    namespace detail
-    {
-
-        // Returns the next largest power of two for a given integer.
-        //
-        // If the provided integer is a power of two, returns its input.
-        inline int bitciel (int n) {
-            if ((n & (n - 1)) == 0)
-                return n;
-
-            int o = 1;
-
-            while (o < n) {
-                o = o << 1;
-            }
-
-            return o;
-        }
-
-    }
 
     // A single sample delay node.
     template <typename FloatType>
@@ -215,7 +195,7 @@ namespace elem
                 // we round up to the next power of two for bit masking tricks around
                 // the delay line length.
                 auto const len = static_cast<int>((js::Number) val);
-                auto const size = detail::bitciel(len + blockSize);
+                auto const size = elem::bitceil(len + blockSize);
                 auto data = bufferPool.allocate();
 
                 // The buffer that we get from the pool may have been

--- a/runtime/elem/builtins/helpers/BitUtils.h
+++ b/runtime/elem/builtins/helpers/BitUtils.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace elem 
+{
+     // calculates the smallest power of two that is greater than or equal to integer `n`
+    inline int bitceil (int n) {
+        if ((n & (n - 1)) == 0)
+            return n;
+
+        int o = 1;
+
+        while (o < n) {
+            o = o << 1;
+        }
+
+        return o;
+    }  
+}


### PR DESCRIPTION
This fix relates back to a discussion on Discord: [link](https://discord.com/channels/826071713426178078/1199094807486791880)

This is a fix suggested by @nick-thompson for an issue with `el.capture` causing the host DAW to crash immediately. Open to any other changes that might be expected for this PR!