### PR TITLE
fix: prevent crossfade on initial render

### DIFF
--- a/runtime/elem/Runtime.h
+++ b/runtime/elem/Runtime.h
@@ -343,7 +343,7 @@ namespace elem
                 return ReturnCode::NodeNotFound();
 
             if (auto ptr = std::dynamic_pointer_cast<RootNode<FloatType>>(nodeTable.at(nodeId))) {
-                ptr->setProperty("active", true);
+                ptr->activate(currentRoots.empty() ? FloatType(1), FloatType(0));
                 active.insert(nodeId);
             }
         }

--- a/runtime/elem/builtins/Core.h
+++ b/runtime/elem/builtins/Core.h
@@ -32,6 +32,12 @@ namespace elem
             return (t >= 0.5 || (std::abs(c - t) >= std::numeric_limits<FloatType>::epsilon()));
         }
 
+        void activate(FloatType initialGain = FloatType(0)) 
+        {
+            setProperty("active", true);
+            currentGain.store(initialGain);
+        }
+
         int setProperty(std::string const& key, js::Value const& val) override
         {
             if (key == "active") {


### PR DESCRIPTION
set currentGain to 1 if currentRoots is empty