### PR TITLE
include whether or not the root node is active in the processing block context

### DIFF
--- a/runtime/elem/GraphRenderSequence.h
+++ b/runtime/elem/GraphRenderSequence.h
@@ -109,8 +109,8 @@ namespace elem
                 bufferMap.insert({{node->getId(), i}, ba.next()});
                 outputPtrs[i] = bufferMap.at({node->getId(), i});
             }
-
-            renderOps.push_back([=, outputPtrs = std::move(outputPtrs)](HostContext<FloatType>& ctx) mutable {
+            
+            renderOps.push_back([=, active = rootPtr->active(), outputPtrs = std::move(outputPtrs)](HostContext<FloatType>& ctx) mutable {
                 node->process(BlockContext<FloatType> {
                     ctx.inputData,
                     ctx.numInputChannels,
@@ -118,6 +118,7 @@ namespace elem
                     numOuts,
                     ctx.numSamples,
                     ctx.userData,
+                    active,
                 });
             });
         }
@@ -148,8 +149,8 @@ namespace elem
             for (size_t j = 0; j < numChildren; ++j) {
                 inputPtrs[j] = bufferMap.at(children[j]);
             }
-
-            renderOps.push_back([=, outputPtrs = std::move(outputPtrs), inputPtrs = std::move(inputPtrs)](HostContext<FloatType>& ctx) mutable {
+            
+            renderOps.push_back([=, active = rootPtr->active(), outputPtrs = std::move(outputPtrs), inputPtrs = std::move(inputPtrs)](HostContext<FloatType>& ctx) mutable {
                 node->process(BlockContext<FloatType> {
                     const_cast<const FloatType**>(inputPtrs.data()),
                     numChildren,
@@ -157,6 +158,7 @@ namespace elem
                     numOuts,
                     ctx.numSamples,
                     ctx.userData,
+                    active,
                 });
             });
         }

--- a/runtime/elem/Types.h
+++ b/runtime/elem/Types.h
@@ -77,6 +77,7 @@ namespace elem
         size_t numOutputChannels;
         size_t numSamples;
         void* userData;
+        bool active;
     };
 
     //==============================================================================

--- a/runtime/elem/builtins/Core.h
+++ b/runtime/elem/builtins/Core.h
@@ -24,6 +24,11 @@ namespace elem
             return targetGain.load();
         }
 
+        bool active()
+        {
+            return targetGain.load() > 0.0f;
+        }
+
         bool stillRunning()
         {
             auto const t = targetGain.load();


### PR DESCRIPTION
Useful for custom nodes whose behavior depends on whether or not it is actually part of the active graph