### PR TITLE
expose fade times for root activation/deactivation

### DIFF
--- a/js/packages/core/index.ts
+++ b/js/packages/core/index.ts
@@ -100,7 +100,7 @@ class Delegate {
     this.batch.setProperty.push([InstructionTypes.SET_PROPERTY, hash, key, value]);
   }
 
-  activateRoots(roots) {
+  activateRoots(roots, fadeInMs, fadeOutMs) {
     // If we're asked to activate exactly the roots that are already active,
     // no need to push the instruction. We need the length/size check though
     // because it may be that we're asked to activate a subset of the current
@@ -110,7 +110,7 @@ class Delegate {
       roots.every((root) => this.currentActiveRoots.has(root));
 
     if (!alreadyActive) {
-      this.batch.activateRoots.push([InstructionTypes.ACTIVATE_ROOTS, roots]);
+      this.batch.activateRoots.push([InstructionTypes.ACTIVATE_ROOTS, roots, fadeInMs, fadeOutMs]);
       this.currentActiveRoots = new Set(roots);
     }
   }
@@ -151,6 +151,9 @@ class Renderer {
   private _delegate: Delegate;
   private _sendMessage: Function;
   private _nextRefId: number;
+
+  // Fades applied to roots when they are activated and deactivated as a result of render
+  rootFades: { inMs: number, outMs: number} = { inMs: 20, outMs: 20 };
 
   constructor(sendMessage) {
     this._delegate = new Delegate();
@@ -202,7 +205,7 @@ class Renderer {
     const t0 = now();
 
     this._delegate.clear();
-    renderWithDelegate(this._delegate as any, args.map(resolve));
+    renderWithDelegate(this._delegate as any, args.map(resolve), this.rootFades.inMs, this.rootFades.outMs);
 
     const t1 = now();
 

--- a/js/packages/core/src/Reconciler.bs.js
+++ b/js/packages/core/src/Reconciler.bs.js
@@ -52,7 +52,7 @@ function visit(delegate, visitSet, _ns) {
   };
 }
 
-function renderWithDelegate(delegate, graphs) {
+function renderWithDelegate(delegate, graphs, rootFadeInMs, rootFadeOutMs) {
   var visitSet = new Set();
   var roots = Belt_List.mapWithIndex(Belt_List.fromArray(graphs), (function (i, g) {
           return NodeRepr.create("root", {
@@ -62,7 +62,7 @@ function renderWithDelegate(delegate, graphs) {
   visit(delegate, visitSet, roots);
   delegate.activateRoots(Belt_List.toArray(Belt_List.map(roots, (function (r) {
                   return r.hash;
-                }))));
+                }))), rootFadeInMs, rootFadeOutMs);
   delegate.commitUpdates();
 }
 

--- a/js/packages/core/src/Reconciler.gen.ts
+++ b/js/packages/core/src/Reconciler.gen.ts
@@ -15,7 +15,7 @@ import type {t as NodeRepr_t} from './NodeRepr.gen';
 // tslint:disable-next-line:max-classes-per-file 
 export abstract class RenderDelegate_t { protected opaque!: any }; /* simulate opaque types */
 
-export const renderWithDelegate: (delegate:RenderDelegate_t, graphs:NodeRepr_t[]) => void = function (Arg1: any, Arg2: any) {
-  const result = Curry._2(ReconcilerBS.renderWithDelegate, Arg1, Arg2);
+export const renderWithDelegate: (delegate:RenderDelegate_t, graphs:NodeRepr_t[], rootFadeInMs:number, rootFadeOutMs:number) => void = function (Arg1: any, Arg2: any, Arg3: any, Arg4: any) {
+  const result = Curry._4(ReconcilerBS.renderWithDelegate, Arg1, Arg2, Arg3, Arg4);
   return result
 };

--- a/js/packages/core/src/Reconciler.res
+++ b/js/packages/core/src/Reconciler.res
@@ -38,7 +38,7 @@ module RenderDelegate = {
   @send external deleteNode: (t, int) => () = "deleteNode"
   @send external appendChild: (t, int, int, int) => () = "appendChild"
   @send external setProperty: (t, int, string, 'a) => () = "setProperty"
-  @send external activateRoots: (t, array<int>) => () = "activateRoots"
+  @send external activateRoots: (t, array<int>, int, int) => () = "activateRoots"
   @send external commitUpdates: t => () = "commitUpdates"
 }
 
@@ -87,14 +87,13 @@ let rec visit = (
 }
 
 @genType
-let renderWithDelegate = (delegate, graphs) => {
+let renderWithDelegate = (delegate, graphs, rootFadeInMs, rootFadeOutMs) => {
   let visitSet = Set.make()
   let roots = Belt.List.mapWithIndex(Belt.List.fromArray(graphs), (i, g) => {
     NodeRepr.create("root", {"channel": i}, [g])
   })
 
   visit(delegate, visitSet, roots)
-
-  RenderDelegate.activateRoots(delegate, Belt.List.toArray(Belt.List.map(roots, r => r.hash)))
+  RenderDelegate.activateRoots(delegate, Belt.List.toArray(Belt.List.map(roots, r => r.hash)), rootFadeInMs, rootFadeOutMs)
   RenderDelegate.commitUpdates(delegate)
 }

--- a/runtime/elem/GraphRenderSequence.h
+++ b/runtime/elem/GraphRenderSequence.h
@@ -178,7 +178,7 @@ namespace elem
         {
             // Don't promote if our RootRenderSequence represents a RootNode that has become
             // inactive, even if it's still fading out
-            if (rootPtr->getTargetGain() < FloatType(0.5))
+            if (!rootPtr->active() && rootPtr->stillRunning())
                 return;
 
             for (auto& n : tapList) {

--- a/runtime/elem/Runtime.h
+++ b/runtime/elem/Runtime.h
@@ -123,7 +123,7 @@ namespace elem
         int createNode(js::Value const& nodeId, js::Value const& type);
         int setProperty(js::Value const& nodeId, js::Value const& prop, js::Value const& v);
         int appendChild(js::Value const& parentId, js::Value const& childId, js::Value const& childOutputChannel);
-        int activateRoots(js::Array const& v);
+        int activateRoots(js::Array const& v, js::Number fadeInMs, js::Number fadeOutMs);
 
         BufferAllocator<FloatType> bufferAllocator;
         std::shared_ptr<GraphRenderSequence<FloatType>> rtRenderSeq;
@@ -190,7 +190,7 @@ namespace elem
                     res = appendChild(ar[1], ar[2], ar[3]);
                     break;
                 case InstructionType::ACTIVATE_ROOTS:
-                    res = activateRoots(ar[1]);
+                    res = activateRoots(ar[1], ar[2], ar[3]);
                     shouldRebuild = true;
                     break;
                 case InstructionType::COMMIT_UPDATES:
@@ -326,7 +326,7 @@ namespace elem
     }
 
     template <typename FloatType>
-    int Runtime<FloatType>::activateRoots(js::Array const& roots)
+    int Runtime<FloatType>::activateRoots(js::Array const& roots, js::Number fadeInMs, js::Number fadeOutMs)
     {
         // Populate and activate from the incoming event
         std::set<NodeId> active;
@@ -354,7 +354,8 @@ namespace elem
             auto ptr = std::dynamic_pointer_cast<RootNode<FloatType>>(it->second);
             if (ptr)
             {
-                ptr->activate(currentRoots.empty() ? FloatType(1) : FloatType(0));
+                ptr->setFades(fadeInMs, fadeOutMs);
+                ptr->setProperty("active", true);
                 active.insert(nodeId);
                 ELEM_DBG("[Success] Activated root: " << nodeIdToHex(nodeId));
             }

--- a/runtime/elem/builtins/helpers/GainFade.h
+++ b/runtime/elem/builtins/helpers/GainFade.h
@@ -9,9 +9,11 @@ namespace elem
     template <typename FloatType>
     struct GainFade
     {
-        GainFade(double sampleRate, double fadeTimeMs)
-            : step(FloatType(1.0 / (sampleRate * fadeTimeMs / 1000.0)))
+        GainFade(double sampleRate, double fadeTimeMs, FloatType current = 0.0, FloatType target = 0.0)
+        : currentGain(current)
+        , targetGain(target)
         {
+            setFadeTimeMs(sampleRate, fadeTimeMs);
         }
 
         GainFade(GainFade const& other)
@@ -34,6 +36,11 @@ namespace elem
             currentGain = std::clamp(currentGain + step, FloatType(0), FloatType(1));
 
             return y;
+        }
+
+        void setFadeTimeMs(double sampleRate, double fadeTimeMs)
+        {
+            step = FloatType(fadeTimeMs > FloatType(1e-6) ? 1.0 / (sampleRate * fadeTimeMs / 1000.0) : 1.0);
         }
 
         void setTargetGain (FloatType g) {


### PR DESCRIPTION
Instead of the baked-in fades that occur with root node activation and deactivation, this exposes individual fade-in and fade-out times (in ms), which can help in cases where we want to preserve transients.