### PR TITLE
Fix missing "name" property in MetroNodeProps

### DIFF
--- a/js/packages/core/lib/core.ts
+++ b/js/packages/core/lib/core.ts
@@ -135,6 +135,7 @@ export function rand(a?) {
 // Metro node
 type MetroNodeProps = {
   key?: string,
+  name?: string,
   interval?: number,
 };
 


### PR DESCRIPTION
Hello, what an amazing project! Just a tiny thing, I noticed MetroNodeProps was missing 'name' property in typedef.