### PR TITLE
fix: add metro to EventTypes interface

### DIFF
--- a/js/packages/core/__tests__/metro-event-type.test.ts
+++ b/js/packages/core/__tests__/metro-event-type.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Type-level test for metro event type.
+ *
+ * This test verifies that 'metro' is recognized as a valid event name
+ * in EventTypes, so that core.on('metro', callback) compiles without
+ * TypeScript errors.
+ *
+ * See: https://github.com/elemaudio/elementary/issues/73
+ */
+import EventEmitter from '../src/Events';
+
+// This should compile without errors: metro is a valid event type
+const emitter = new EventEmitter();
+
+emitter.on('metro', (data) => {
+  // The metro event payload should have an optional source field
+  const source: string | undefined = data.source;
+});

--- a/js/packages/core/src/Events.ts
+++ b/js/packages/core/src/Events.ts
@@ -7,6 +7,7 @@ type EventTypes = {
   fft: (data: { source?: string, data: { real: Float32Array, imag: Float32Array } }) => void;
   load: () => void;
   meter: (data: { source?: string, min: number; max: number, }) => void;
+  metro: (data: { source?: string }) => void;
   scope: (data: { source?: string, data: Float32Array[] }) => void;
   snapshot: (data: { source?: string, data: number }) => void;
 };


### PR DESCRIPTION
## Summary

- Add `metro` event type to the `EventTypes` interface in `Events.ts`, matching the C++ `MetronomeNode::processEvents` payload shape
- TypeScript now accepts `core.on('metro', callback)` without type errors

Fixes #73

## Test plan

- [x] `tsc --noEmit` compiles cleanly with the new type
- [x] Type-level test confirms `'metro'` is accepted as a valid event name
- [x] Removing the `metro` line produces TS2345 (negative check)

## Hypothesis graph

Reasoning trace and attestation for this fix: https://github.com/kimjune01/sweep/blob/master/repo-hypotheses/elemaudio-elementary.md
