### PR TITLE
Fix Runtime::snapshot access to GraphEntry node

### DIFF
--- a/runtime/elem/Runtime.h
+++ b/runtime/elem/Runtime.h
@@ -491,8 +491,8 @@ namespace elem
     {
         js::Object ret;
 
-        for (auto& [nodeId, node] : nodeTable) {
-            ret.insert({nodeIdToHex(nodeId), node->getProperties()});
+        for (auto& [nodeId, entry] : nodeTable) {
+            ret.insert({nodeIdToHex(nodeId), entry.node->getProperties()});
         }
 
         return ret;


### PR DESCRIPTION
  ## Summary

  Fix `Runtime::snapshot()` to access `getProperties()` through the
  `GraphNode` stored in each `GraphEntry`.

  `nodeTable` maps `NodeId` to `GraphEntry`, but `GraphEntry` itself does not
  provide `getProperties()`. The method belongs to `GraphEntry::node`.

  This regression appears to have been introduced in
  a8923b85e173b04ec3a3145ff1ed37f536789072, when the mapped type of
  `nodeTable` was changed from `std::shared_ptr<GraphNode<FloatType>>` to
  `GraphEntry`.

  ## Reproduction

  At commit 60e7234, run the following from the repository root:

  ```sh
❯ printf '#include "elem/Runtime.h"\nvoid test(elem::Runtime<float>& r)
{ (void)r.snapshot(); }\n' \
  | c++ -Iruntime -std=c++17 -fsyntax-only -x c++ -
In file included from <stdin>:1:
runtime/elem/Runtime.h:495:50: error: member reference type 'std::tuple_element<1, std::pair<const int, elem::Runtime<float>::GraphEntry>>::type' (aka 'elem::Runtime<float>::GraphEntry') is not a pointer; did you mean to use '.'?
            ret.insert({nodeIdToHex(nodeId), node->getProperties()});
                                             ~~~~^~
                                                 .
<stdin>:3:11: note: in instantiation of member function 'elem::Runtime<float>::snapshot' requested here
{ (void)r.snapshot(); }
          ^
In file included from <stdin>:1:
runtime/elem/Runtime.h:495:52: error: no member named 'getProperties' in 'elem::Runtime<float>::GraphEntry'
            ret.insert({nodeIdToHex(nodeId), node->getProperties()});
                                             ~~~~  ^
2 errors generated.
 ```

  Compilation fails with:

  error: no member named 'getProperties' in 'elem::Runtime<float>::GraphEntry'

  The regular native build does not detect this because Runtime is a class
  template and snapshot() is not instantiated unless it is used.

  Change:

  node->getProperties()

  to:

  entry.node->getProperties()

  The reproduction command succeeds after this change.